### PR TITLE
Ensure pytest can import the acmecli package

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))


### PR DESCRIPTION
## Summary
- add a repository-level `conftest.py` that places the `src` directory on `sys.path`
- allow the `acmecli` package to import correctly when running the pytest suite

## Testing
- pytest -q
- python run.py test

------
https://chatgpt.com/codex/tasks/task_e_68d9cead0f2c8324ba0f3ecbe8bb2586